### PR TITLE
Add support for `fixed` data type (with logical type `decimal`) for `…

### DIFF
--- a/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/DefaultParamMatcher.scala
@@ -48,7 +48,11 @@ object DefaultParamMatcher {
           case UUID => REF("java.util.UUID.randomUUID")
         }
       case Type.NULL    => NULL
-      case Type.FIXED   => sys.error("the FIXED datatype is not yet supported")
+      case Type.FIXED   =>
+        CustomDefaultParamMatcher.checkCustomDecimalType(
+          decimalType = typeMatcher.avroScalaTypes.decimal,
+          schema = avroSchema,
+          default = NULL)
       case Type.ENUM    =>
         CustomDefaultParamMatcher.checkCustomEnumType(typeMatcher.avroScalaTypes.enum)
       case Type.BYTES   =>

--- a/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
+++ b/avrohugger-core/src/main/scala/matchers/TypeMatcher.scala
@@ -61,7 +61,7 @@ class TypeMatcher(
             default = StringClass) {
             case UUID => RootClass.newClass(nme.createNameType("java.util.UUID"))
           }
-        case Schema.Type.FIXED    => sys.error("FIXED datatype not yet supported")
+        case Schema.Type.FIXED    => CustomTypeMatcher.checkCustomDecimalType(avroScalaTypes.decimal, schema)
         case Schema.Type.BYTES    => CustomTypeMatcher.checkCustomDecimalType(avroScalaTypes.decimal, schema)
         case Schema.Type.RECORD   => classStore.generatedClasses(schema)
         case Schema.Type.ENUM     => CustomTypeMatcher.checkCustomEnumType(avroScalaTypes.enum, classStore, schema)

--- a/avrohugger-core/src/test/avro/logical.avsc
+++ b/avrohugger-core/src/test/avro/logical.avsc
@@ -13,6 +13,17 @@
       }
     },
     {
+      "name": "fxField",
+      "type": {
+        "type": "fixed",
+        "name": "fxType",
+        "size": 12,
+        "logicalType": "decimal",
+        "precision": 5,
+        "scale": 2
+      }
+    },
+    {
       "name": "ts",
       "type": {
         "type": "long",

--- a/avrohugger-core/src/test/expected/specific/example/logical/LogicalSc.scala
+++ b/avrohugger-core/src/test/expected/specific/example/logical/LogicalSc.scala
@@ -3,7 +3,7 @@ package example.logical
 
 import scala.annotation.switch
 
-final case class LogicalSc(var data: BigDecimal, var ts: java.time.Instant, var dt: java.time.LocalDate, var uuid: java.util.UUID, var dataBig: BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
+final case class LogicalSc(var data: BigDecimal, var fxField: BigDecimal, var ts: java.time.Instant, var dt: java.time.LocalDate, var uuid: java.util.UUID, var dataBig: BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
   def this() = this(scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {

--- a/avrohugger-core/src/test/expected/standard-tagged/example/logical/LogicalSc.scala
+++ b/avrohugger-core/src/test/expected/standard-tagged/example/logical/LogicalSc.scala
@@ -3,4 +3,4 @@ package example.logical
 
 import shapeless.tag.@@
 
-final case class LogicalSc(data: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))])
+final case class LogicalSc(data: @@[scala.math.BigDecimal, (shapeless.Nat._9, shapeless.Nat._2)], fxField: @@[scala.math.BigDecimal, (shapeless.Nat._5, shapeless.Nat._2)], ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: @@[scala.math.BigDecimal, ((shapeless.Nat._2, shapeless.Nat._0), (shapeless.Nat._1, shapeless.Nat._2))])

--- a/avrohugger-core/src/test/expected/standard/example/logical/LogicalSc.scala
+++ b/avrohugger-core/src/test/expected/standard/example/logical/LogicalSc.scala
@@ -1,4 +1,4 @@
 /** MACHINE-GENERATED FROM AVRO SCHEMA. DO NOT EDIT DIRECTLY */
 package example.logical
 
-final case class LogicalSc(data: BigDecimal, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: BigDecimal)
+final case class LogicalSc(data: BigDecimal, fxField: BigDecimal, ts: java.time.Instant, dt: java.time.LocalDate, uuid: java.util.UUID, dataBig: BigDecimal)

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ lazy val avroVersion = "1.9.1"
 
 lazy val commonSettings = Seq(
   organization := "com.julianpeeters",
-  version := "1.0.0-RC24",
+  version := "1.0.0-RC25",
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
-  scalacOptions in Test ++= Seq("-Yrangepos"),
+  Test / scalacOptions ++= Seq("-Yrangepos"),
   scalaVersion := "2.13.4",
   crossScalaVersions := Seq("2.12.10", scalaVersion.value),
   resolvers += Resolver.typesafeIvyRepo("releases"),
@@ -31,7 +31,7 @@ lazy val commonSettings = Seq(
   // for testing
   libraryDependencies += "org.specs2" %% "specs2-core" % "4.8.0" % "test",
   publishMavenStyle := true,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   publishTo := Some(
   if (isSnapshot.value)
     Opts.resolver.sonatypeSnapshots
@@ -57,7 +57,7 @@ lazy val commonSettings = Seq(
 
 lazy val avrohugger = (project in file("."))
   .settings(
-    commonSettings,
+    commonSettings
   ).aggregate(`avrohugger-core`, `avrohugger-filesorter`, `avrohugger-tools`)
 
 
@@ -77,9 +77,9 @@ lazy val `avrohugger-tools` = (project in file("avrohugger-tools"))
   .settings(
     commonSettings,
     libraryDependencies += "org.apache.avro" % "avro-tools" % avroVersion,
-    artifact in (Compile, assembly) := {
-      val art: Artifact = (artifact in (Compile, assembly)).value
+    Compile / assembly / artifact := {
+      val art: Artifact = (Compile / assembly / artifact).value
       art.withClassifier(Some("assembly"))
     },
-    addArtifact(artifact in (Compile, assembly), assembly).settings
+    addArtifact(Compile / assembly / artifact, assembly).settings
   ).dependsOn(`avrohugger-core`, `avrohugger-filesorter`)


### PR DESCRIPTION
…Standard` and `SpecificRecord` formats.

Logical type `decimal` is mapped to `BigDecimal` of Scala,
and bare `fixed` is mapped to `Array[Byte]`.