### PR TITLE
Fixed data type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.4, 2.12.10]
+        scala: [2.13.4, 2.12.11]
         java: [adopt@1.8, adopt@1.11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -19,8 +19,8 @@ object Standard extends SourceFormat {
 
   val toolShortDescription = "Generates Scala code for the given schema."
 
-  val javaTreehugger: StandardJavaTreehugger.type = StandardJavaTreehugger
-  val scalaTreehugger: StandardScalaTreehugger.type = StandardScalaTreehugger
+  val javaTreehugger = StandardJavaTreehugger
+  val scalaTreehugger = StandardScalaTreehugger
 
   def asCompilationUnits(
     classStore: ClassStore,

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -40,7 +40,7 @@ object Standard extends SourceFormat {
     val enumType = typeMatcher.avroScalaTypes.enum
 
     schemaOrProtocol match {
-      case Left(schema) =>
+      case Left(schema) => {
         schema.getType match {
           case RECORD => {
             val scalaCompilationUnit = getScalaCompilationUnit(
@@ -53,7 +53,7 @@ object Standard extends SourceFormat {
               restrictedFields)
             List(scalaCompilationUnit)
           }
-          case ENUM =>
+          case ENUM => {
             enumType match {
               // java enums can't be represented as trees so they can't be
               // handled by treehugger. Their compilation unit must de generated
@@ -92,10 +92,12 @@ object Standard extends SourceFormat {
               }
               case EnumAsScalaString => List.empty
             }
+          }
           case FIXED => List.empty
 
           case _ => sys.error("Only RECORD, ENUM or FIXED can be toplevel definitions")
         }
+      }
       case Right(protocol) => {
         val scalaCompilationUnit = getScalaCompilationUnit(
           classStore,

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -94,8 +94,14 @@ object Standard extends SourceFormat {
           case _ => sys.error("Only RECORD, ENUM or FIXED can be toplevel definitions")
         }
       case Right(protocol) => {
-        val scalaCompilationUnit =
-          getScalaCompilationUnit(classStore, namespace, Right(protocol), typeMatcher, schemaStore, maybeOutDir, restrictedFields)
+        val scalaCompilationUnit = getScalaCompilationUnit(
+          classStore,
+          namespace,
+          Right(protocol),
+          typeMatcher,
+          schemaStore,
+          maybeOutDir,
+          restrictedFields)
         enumType match {
           // java enums can't be represented as trees so they can't be handled
           // by treehugger. Their compilation unit must de generated
@@ -105,7 +111,12 @@ object Standard extends SourceFormat {
             val localRecords = localSubtypes.filterNot(isEnum)
             val localEnums = localSubtypes.filter(isEnum)
             val javaCompilationUnits = localEnums.map(schema =>
-              getJavaEnumCompilationUnit(classStore, namespace, schema, maybeOutDir, typeMatcher)
+              getJavaEnumCompilationUnit(
+                classStore,
+                namespace,
+                schema,
+                maybeOutDir,
+                typeMatcher)
             )
             if (localRecords.length >= 1) scalaCompilationUnit +: javaCompilationUnits
             else javaCompilationUnits
@@ -139,7 +150,9 @@ object Standard extends SourceFormat {
 
   val defaultTypes: AvroScalaTypes = AvroScalaTypes.defaults
 
-  def getName(schemaOrProtocol: Either[Schema, Protocol], typeMatcher: TypeMatcher): String = {
+  def getName(
+      schemaOrProtocol: Either[Schema, Protocol],
+      typeMatcher: TypeMatcher): String = {
     schemaOrProtocol match {
       case Left(schema) => schema.getName
       case Right(protocol) => {

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -90,7 +90,9 @@ object Standard extends SourceFormat {
                   restrictedFields)
                 List(scalaCompilationUnit)
               }
-              case EnumAsScalaString => List.empty
+              case EnumAsScalaString => {
+                List.empty
+              }
             }
           }
           case FIXED => List.empty
@@ -156,8 +158,8 @@ object Standard extends SourceFormat {
   val defaultTypes: AvroScalaTypes = AvroScalaTypes.defaults
 
   def getName(
-      schemaOrProtocol: Either[Schema, Protocol],
-      typeMatcher: TypeMatcher): String = {
+    schemaOrProtocol: Either[Schema, Protocol],
+    typeMatcher: TypeMatcher): String = {
     schemaOrProtocol match {
       case Left(schema) => schema.getName
       case Right(protocol) => {

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -29,8 +29,7 @@ object Standard extends SourceFormat {
     schemaStore: SchemaStore,
     maybeOutDir: Option[String],
     typeMatcher: TypeMatcher,
-    restrictedFields: Boolean
-  ): List[CompilationUnit] = {
+    restrictedFields: Boolean): List[CompilationUnit] = {
     registerTypes(schemaOrProtocol, classStore, typeMatcher)
     val namespace =
       CustomNamespaceMatcher.checkCustomNamespace(

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -43,7 +43,7 @@ object Standard extends SourceFormat {
     schemaOrProtocol match {
       case Left(schema) =>
         schema.getType match {
-          case RECORD =>
+          case RECORD => {
             val scalaCompilationUnit = getScalaCompilationUnit(
               classStore,
               namespace,
@@ -53,13 +53,14 @@ object Standard extends SourceFormat {
               maybeOutDir,
               restrictedFields)
             List(scalaCompilationUnit)
+          }
           case ENUM =>
             enumType match {
               // java enums can't be represented as trees so they can't be
               // handled by treehugger. Their compilation unit must de generated
               // separately, and they will be excluded from scala compilation
               // units.
-              case JavaEnum =>
+              case JavaEnum => {
                 val javaCompilationUnit = getJavaEnumCompilationUnit(
                   classStore,
                   namespace,
@@ -67,7 +68,8 @@ object Standard extends SourceFormat {
                   maybeOutDir,
                   typeMatcher)
                 List(javaCompilationUnit)
-              case ScalaCaseObjectEnum =>
+              }
+              case ScalaCaseObjectEnum => {
                 val scalaCompilationUnit = getScalaCompilationUnit(
                   classStore,
                   namespace,
@@ -77,7 +79,8 @@ object Standard extends SourceFormat {
                   maybeOutDir,
                   restrictedFields)
                 List(scalaCompilationUnit)
-              case ScalaEnumeration =>
+              }
+              case ScalaEnumeration => {
                 val scalaCompilationUnit = getScalaCompilationUnit(
                   classStore,
                   namespace,
@@ -87,6 +90,7 @@ object Standard extends SourceFormat {
                   maybeOutDir,
                   restrictedFields)
                 List(scalaCompilationUnit)
+              }
               case EnumAsScalaString => List.empty
             }
           case FIXED => List.empty

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -44,8 +44,14 @@ object Standard extends SourceFormat {
       case Left(schema) =>
         schema.getType match {
           case RECORD =>
-            val scalaCompilationUnit =
-              getScalaCompilationUnit(classStore, namespace, schemaOrProtocol, typeMatcher, schemaStore, maybeOutDir, restrictedFields)
+            val scalaCompilationUnit = getScalaCompilationUnit(
+              classStore,
+              namespace,
+              schemaOrProtocol,
+              typeMatcher,
+              schemaStore,
+              maybeOutDir,
+              restrictedFields)
             List(scalaCompilationUnit)
           case ENUM =>
             enumType match {
@@ -54,16 +60,32 @@ object Standard extends SourceFormat {
               // separately, and they will be excluded from scala compilation
               // units.
               case JavaEnum =>
-                val javaCompilationUnit =
-                  getJavaEnumCompilationUnit(classStore, namespace, schema, maybeOutDir, typeMatcher)
+                val javaCompilationUnit = getJavaEnumCompilationUnit(
+                  classStore,
+                  namespace,
+                  schema,
+                  maybeOutDir,
+                  typeMatcher)
                 List(javaCompilationUnit)
               case ScalaCaseObjectEnum =>
-                val scalaCompilationUnit =
-                  getScalaCompilationUnit(classStore, namespace, schemaOrProtocol, typeMatcher, schemaStore, maybeOutDir, restrictedFields)
+                val scalaCompilationUnit = getScalaCompilationUnit(
+                  classStore,
+                  namespace,
+                  schemaOrProtocol,
+                  typeMatcher,
+                  schemaStore,
+                  maybeOutDir,
+                  restrictedFields)
                 List(scalaCompilationUnit)
               case ScalaEnumeration =>
-                val scalaCompilationUnit =
-                  getScalaCompilationUnit(classStore, namespace, schemaOrProtocol, typeMatcher, schemaStore, maybeOutDir, restrictedFields)
+                val scalaCompilationUnit = getScalaCompilationUnit(
+                  classStore,
+                  namespace,
+                  schemaOrProtocol,
+                  typeMatcher,
+                  schemaStore,
+                  maybeOutDir,
+                  restrictedFields)
                 List(scalaCompilationUnit)
               case EnumAsScalaString => List.empty
             }

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -23,13 +23,13 @@ object Standard extends SourceFormat {
   val scalaTreehugger: StandardScalaTreehugger.type = StandardScalaTreehugger
 
   def asCompilationUnits(
-      classStore: ClassStore,
-      ns: Option[String],
-      schemaOrProtocol: Either[Schema, Protocol],
-      schemaStore: SchemaStore,
-      maybeOutDir: Option[String],
-      typeMatcher: TypeMatcher,
-      restrictedFields: Boolean
+    classStore: ClassStore,
+    ns: Option[String],
+    schemaOrProtocol: Either[Schema, Protocol],
+    schemaStore: SchemaStore,
+    maybeOutDir: Option[String],
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean
   ): List[CompilationUnit] = {
     registerTypes(schemaOrProtocol, classStore, typeMatcher)
     val namespace =
@@ -110,7 +110,7 @@ object Standard extends SourceFormat {
           // java enums can't be represented as trees so they can't be handled
           // by treehugger. Their compilation unit must de generated
           // separately, and they will be excluded from scala compilation units.
-          case JavaEnum =>
+          case JavaEnum => {
             val localSubtypes = getLocalSubtypes(protocol)
             val localRecords = localSubtypes.filterNot(isEnum)
             val localEnums = localSubtypes.filter(isEnum)
@@ -124,6 +124,7 @@ object Standard extends SourceFormat {
             )
             if (localRecords.length >= 1) scalaCompilationUnit +: javaCompilationUnits
             else javaCompilationUnits
+          }
           case ScalaCaseObjectEnum => List(scalaCompilationUnit)
           case ScalaEnumeration => List(scalaCompilationUnit)
           case EnumAsScalaString => List(scalaCompilationUnit)

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -115,14 +115,14 @@ object Standard extends SourceFormat {
             val localSubtypes = getLocalSubtypes(protocol)
             val localRecords = localSubtypes.filterNot(isEnum)
             val localEnums = localSubtypes.filter(isEnum)
-            val javaCompilationUnits = localEnums.map(schema =>
+            val javaCompilationUnits = localEnums.map(schema => {
               getJavaEnumCompilationUnit(
                 classStore,
                 namespace,
                 schema,
                 maybeOutDir,
                 typeMatcher)
-            )
+            })
             if (localRecords.length >= 1) scalaCompilationUnit +: javaCompilationUnits
             else javaCompilationUnits
           }
@@ -135,14 +135,13 @@ object Standard extends SourceFormat {
   }
 
   def compile(
-      classStore: ClassStore,
-      ns: Option[String],
-      schemaOrProtocol: Either[Schema, Protocol],
-      outDir: String,
-      schemaStore: SchemaStore,
-      typeMatcher: TypeMatcher,
-      restrictedFields: Boolean
-  ): Unit = {
+    classStore: ClassStore,
+    ns: Option[String],
+    schemaOrProtocol: Either[Schema, Protocol],
+    outDir: String,
+    schemaStore: SchemaStore,
+    typeMatcher: TypeMatcher,
+    restrictedFields: Boolean): Unit = {
     val compilationUnits: List[CompilationUnit] = asCompilationUnits(
       classStore,
       ns,

--- a/avrohugger-core/src/main/scala/format/Standard.scala
+++ b/avrohugger-core/src/main/scala/format/Standard.scala
@@ -6,14 +6,12 @@ import format.standard._
 import matchers.TypeMatcher
 import matchers.custom.{CustomNamespaceMatcher, CustomTypeMatcher}
 import models.CompilationUnit
-import stores.{ ClassStore, SchemaStore }
+import stores.{ClassStore, SchemaStore}
 import types._
-
 import treehugger.forest._
 import definitions.RootClass
-
-import org.apache.avro.{ Protocol, Schema }
-import org.apache.avro.Schema.Type.{ ENUM, RECORD }
+import org.apache.avro.{Protocol, Schema}
+import org.apache.avro.Schema.Type.{ENUM, FIXED, RECORD}
 
 object Standard extends SourceFormat {
 
@@ -21,17 +19,18 @@ object Standard extends SourceFormat {
 
   val toolShortDescription = "Generates Scala code for the given schema."
 
-  val javaTreehugger = StandardJavaTreehugger
-  val scalaTreehugger = StandardScalaTreehugger
+  val javaTreehugger: StandardJavaTreehugger.type = StandardJavaTreehugger
+  val scalaTreehugger: StandardScalaTreehugger.type = StandardScalaTreehugger
 
   def asCompilationUnits(
-    classStore: ClassStore,
-    ns: Option[String],
-    schemaOrProtocol: Either[Schema, Protocol],
-    schemaStore: SchemaStore,
-    maybeOutDir: Option[String],
-    typeMatcher: TypeMatcher,
-    restrictedFields: Boolean): List[CompilationUnit] = {
+      classStore: ClassStore,
+      ns: Option[String],
+      schemaOrProtocol: Either[Schema, Protocol],
+      schemaStore: SchemaStore,
+      maybeOutDir: Option[String],
+      typeMatcher: TypeMatcher,
+      restrictedFields: Boolean
+  ): List[CompilationUnit] = {
     registerTypes(schemaOrProtocol, classStore, typeMatcher)
     val namespace =
       CustomNamespaceMatcher.checkCustomNamespace(
@@ -42,93 +41,52 @@ object Standard extends SourceFormat {
     val enumType = typeMatcher.avroScalaTypes.enum
 
     schemaOrProtocol match {
-      case Left(schema) => {
+      case Left(schema) =>
         schema.getType match {
-          case RECORD => {
-            val scalaCompilationUnit = getScalaCompilationUnit(
-              classStore,
-              namespace,
-              schemaOrProtocol,
-              typeMatcher,
-              schemaStore,
-              maybeOutDir,
-              restrictedFields)
+          case RECORD =>
+            val scalaCompilationUnit =
+              getScalaCompilationUnit(classStore, namespace, schemaOrProtocol, typeMatcher, schemaStore, maybeOutDir, restrictedFields)
             List(scalaCompilationUnit)
-          }
-          case ENUM => {
+          case ENUM =>
             enumType match {
               // java enums can't be represented as trees so they can't be
               // handled by treehugger. Their compilation unit must de generated
               // separately, and they will be excluded from scala compilation
               // units.
-              case JavaEnum => {
-                val javaCompilationUnit = getJavaEnumCompilationUnit(
-                  classStore,
-                  namespace,
-                  schema,
-                  maybeOutDir,
-                  typeMatcher)
+              case JavaEnum =>
+                val javaCompilationUnit =
+                  getJavaEnumCompilationUnit(classStore, namespace, schema, maybeOutDir, typeMatcher)
                 List(javaCompilationUnit)
-              }
-              case ScalaCaseObjectEnum => {
-                val scalaCompilationUnit = getScalaCompilationUnit(
-                  classStore,
-                  namespace,
-                  schemaOrProtocol,
-                  typeMatcher,
-                  schemaStore,
-                  maybeOutDir,
-                  restrictedFields)
+              case ScalaCaseObjectEnum =>
+                val scalaCompilationUnit =
+                  getScalaCompilationUnit(classStore, namespace, schemaOrProtocol, typeMatcher, schemaStore, maybeOutDir, restrictedFields)
                 List(scalaCompilationUnit)
-              }
-              case ScalaEnumeration => {
-                val scalaCompilationUnit = getScalaCompilationUnit(
-                  classStore,
-                  namespace,
-                  schemaOrProtocol,
-                  typeMatcher,
-                  schemaStore,
-                  maybeOutDir,
-                  restrictedFields)
+              case ScalaEnumeration =>
+                val scalaCompilationUnit =
+                  getScalaCompilationUnit(classStore, namespace, schemaOrProtocol, typeMatcher, schemaStore, maybeOutDir, restrictedFields)
                 List(scalaCompilationUnit)
-              }
-              case EnumAsScalaString => {
-                List.empty
-              }
+              case EnumAsScalaString => List.empty
             }
+          case FIXED => List.empty
 
-          }
-          case _ => sys.error("Only RECORD or ENUM can be toplevel definitions")
+          case _ => sys.error("Only RECORD, ENUM or FIXED can be toplevel definitions")
         }
-      }
       case Right(protocol) => {
-        val scalaCompilationUnit = getScalaCompilationUnit(
-          classStore,
-          namespace,
-          Right(protocol),
-          typeMatcher,
-          schemaStore,
-          maybeOutDir,
-          restrictedFields)
+        val scalaCompilationUnit =
+          getScalaCompilationUnit(classStore, namespace, Right(protocol), typeMatcher, schemaStore, maybeOutDir, restrictedFields)
         enumType match {
           // java enums can't be represented as trees so they can't be handled
           // by treehugger. Their compilation unit must de generated
           // separately, and they will be excluded from scala compilation units.
-          case JavaEnum => {
+          case JavaEnum =>
             val localSubtypes = getLocalSubtypes(protocol)
             val localRecords = localSubtypes.filterNot(isEnum)
             val localEnums = localSubtypes.filter(isEnum)
-            val javaCompilationUnits = localEnums.map(schema => {
-              getJavaEnumCompilationUnit(
-                classStore,
-                namespace,
-                schema,
-                maybeOutDir,
-                typeMatcher)
-            })
+            val javaCompilationUnits = localEnums.map(schema =>
+              getJavaEnumCompilationUnit(classStore, namespace, schema, maybeOutDir, typeMatcher)
+            )
             if (localRecords.length >= 1) scalaCompilationUnit +: javaCompilationUnits
             else javaCompilationUnits
-          }
           case ScalaCaseObjectEnum => List(scalaCompilationUnit)
           case ScalaEnumeration => List(scalaCompilationUnit)
           case EnumAsScalaString => List(scalaCompilationUnit)
@@ -138,13 +96,14 @@ object Standard extends SourceFormat {
   }
 
   def compile(
-    classStore: ClassStore,
-    ns: Option[String],
-    schemaOrProtocol: Either[Schema, Protocol],
-    outDir: String,
-    schemaStore: SchemaStore,
-    typeMatcher: TypeMatcher,
-    restrictedFields: Boolean): Unit = {
+      classStore: ClassStore,
+      ns: Option[String],
+      schemaOrProtocol: Either[Schema, Protocol],
+      outDir: String,
+      schemaStore: SchemaStore,
+      typeMatcher: TypeMatcher,
+      restrictedFields: Boolean
+  ): Unit = {
     val compilationUnits: List[CompilationUnit] = asCompilationUnits(
       classStore,
       ns,
@@ -155,12 +114,10 @@ object Standard extends SourceFormat {
       restrictedFields)
     compilationUnits.foreach(writeToFile)
   }
-  
+
   val defaultTypes: AvroScalaTypes = AvroScalaTypes.defaults
 
-  def getName(
-    schemaOrProtocol: Either[Schema, Protocol],
-    typeMatcher: TypeMatcher): String = {
+  def getName(schemaOrProtocol: Either[Schema, Protocol], typeMatcher: TypeMatcher): String = {
     schemaOrProtocol match {
       case Left(schema) => schema.getName
       case Right(protocol) => {
@@ -173,7 +130,7 @@ object Standard extends SourceFormat {
         if (localSubTypes.length > 1) protocol.getName // for ADT
         else localSubTypes.headOption match {
           case Some(schema) => schema.getName // for single class defintion
-          case None => protocol.getName  // default to protocol name
+          case None => protocol.getName // default to protocol name
         }
       }
     }

--- a/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
@@ -4,20 +4,18 @@ package abstractions
 
 import avrohugger.matchers.TypeMatcher
 import avrohugger.models.CompilationUnit
-import avrohugger.stores.{ ClassStore, SchemaStore }
+import avrohugger.stores.{ClassStore, SchemaStore}
 import avrohugger.types._
+import org.apache.avro.{Protocol, Schema}
+import org.apache.avro.Schema.Type.{ENUM, FIXED, RECORD}
 
-import org.apache.avro.{ Protocol, Schema }
-import org.apache.avro.Schema.Type.{ ENUM, RECORD }
-
-import java.nio.file.{ Path, Paths, Files, StandardOpenOption }
-import java.io.{ File, FileNotFoundException, IOException }
-
+import java.nio.file.{Files, Path, Paths, StandardOpenOption}
+import java.io.{File, FileNotFoundException, IOException}
 import treehugger.forest._
 import definitions._
 import treehuggerDSL._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Parent to all ouput formats
   *
@@ -107,7 +105,7 @@ trait SourceFormat {
     maybeOutDir: Option[String],
     typeMatcher: TypeMatcher): Option[Path] = {
     maybeOutDir match {
-      case Some(outDir) => {
+      case Some(outDir) =>
         val folderPath: Path = Paths.get{
           if (namespace.isDefined) {
             s"$outDir/${namespace.get.toString.replace('.','/')}"
@@ -118,7 +116,6 @@ trait SourceFormat {
         val fileName = getName(schemaOrProtocol, typeMatcher) + ext
         if (!Files.exists(folderPath)) Files.createDirectories(folderPath)
         Some(Paths.get(s"$folderPath/$fileName"))
-      }
       case None => None
     }
 
@@ -169,7 +166,7 @@ trait SourceFormat {
     CompilationUnit(scalaFilePath, scalaString)
   }
 
-  def isEnum(schema: Schema) = schema.getType == Schema.Type.ENUM
+  def isEnum(schema: Schema): Boolean = schema.getType == Schema.Type.ENUM
 
   def registerTypes(
     schemaOrProtocol: Either[Schema, Protocol],
@@ -193,11 +190,12 @@ trait SourceFormat {
     }
   }
 
-  def renameEnum(schema: Schema, selector: String) = {
+  def renameEnum(schema: Schema, selector: String): String = {
     schema.getType match {
       case RECORD => schema.getName
       case ENUM => schema.getName + "." + selector
-      case _ => sys.error("Only RECORD and ENUM can be top-level definitions")
+      case FIXED => schema.getName
+      case _ => sys.error("Only RECORD, ENUM or FIXED can be top-level definitions")
     }
   }
   

--- a/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
+++ b/avrohugger-core/src/main/scala/format/abstractions/SourceFormat.scala
@@ -105,10 +105,10 @@ trait SourceFormat {
     maybeOutDir: Option[String],
     typeMatcher: TypeMatcher): Option[Path] = {
     maybeOutDir match {
-      case Some(outDir) =>
-        val folderPath: Path = Paths.get{
+      case Some(outDir) => {
+        val folderPath: Path = Paths.get {
           if (namespace.isDefined) {
-            s"$outDir/${namespace.get.toString.replace('.','/')}"
+            s"$outDir/${namespace.get.toString.replace('.', '/')}"
           }
           else outDir
         }
@@ -116,6 +116,7 @@ trait SourceFormat {
         val fileName = getName(schemaOrProtocol, typeMatcher) + ext
         if (!Files.exists(folderPath)) Files.createDirectories(folderPath)
         Some(Paths.get(s"$folderPath/$fileName"))
+      }
       case None => None
     }
 

--- a/avrohugger-core/src/main/scala/input/parsers/FileInputParser.scala
+++ b/avrohugger-core/src/main/scala/input/parsers/FileInputParser.scala
@@ -4,17 +4,16 @@ package parsers
 
 import format.abstractions.SourceFormat
 import stores.ClassStore
-
-import org.apache.avro.{ Protocol, Schema }
+import org.apache.avro.{Protocol, Schema}
 import org.apache.avro.Schema.Parser
-import org.apache.avro.Schema.Type.{ RECORD, UNION, ENUM }
+import org.apache.avro.Schema.Type.{ENUM, FIXED, RECORD, UNION}
 import org.apache.avro.compiler.idl.Idl
-import org.apache.avro.generic.{ GenericDatumReader, GenericRecord }
+import org.apache.avro.generic.{GenericDatumReader, GenericRecord}
 import org.apache.avro.file.DataFileReader
 import org.apache.avro.SchemaParseException
-import java.io.File
 
-import scala.collection.JavaConverters._
+import java.io.File
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class FileInputParser {
@@ -32,6 +31,7 @@ class FileInputParser {
         case UNION => schema.getTypes.asScala.toList
         case RECORD => List(schema)
         case ENUM => List(schema)
+        case FIXED => List(schema)
         case _ => sys.error("""Neither a record, enum nor a union of either. 
           |Nothing to map to a definition.""".trim.stripMargin)
       }

--- a/avrohugger-core/src/test/avro/fixed.avsc
+++ b/avrohugger-core/src/test/avro/fixed.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "fixed",
+  "size": 12,
+  "namespace": "example",
+  "name": "Fixed",
+  "logicalType": "decimal",
+  "precision": 28,
+  "scale": 15
+}

--- a/avrohugger-core/src/test/expected/specific/example/logical/LogicalSc.scala
+++ b/avrohugger-core/src/test/expected/specific/example/logical/LogicalSc.scala
@@ -4,7 +4,7 @@ package example.logical
 import scala.annotation.switch
 
 final case class LogicalSc(var data: BigDecimal, var fxField: BigDecimal, var ts: java.time.Instant, var dt: java.time.LocalDate, var uuid: java.util.UUID, var dataBig: BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
+  def this() = this(scala.math.BigDecimal(0), scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
@@ -16,15 +16,23 @@ final case class LogicalSc(var data: BigDecimal, var fxField: BigDecimal, var ts
         LogicalSc.decimalConversion.toBytes(bigDecimal, schema, decimalType)
       }.asInstanceOf[AnyRef]
       case 1 => {
-        ts.toEpochMilli
+        val schema = getSchema.getFields().get(field$).schema()
+        val decimalType = schema.getLogicalType().asInstanceOf[org.apache.avro.LogicalTypes.Decimal]
+        val scale = decimalType.getScale()
+        val scaledValue = fxField.setScale(scale)
+        val bigDecimal = scaledValue.bigDecimal
+        LogicalSc.decimalConversion.toBytes(bigDecimal, schema, decimalType)
       }.asInstanceOf[AnyRef]
       case 2 => {
-        dt.toEpochDay.toInt
+        ts.toEpochMilli
       }.asInstanceOf[AnyRef]
       case 3 => {
-        uuid.toString
+        dt.toEpochDay.toInt
       }.asInstanceOf[AnyRef]
       case 4 => {
+        uuid.toString
+      }.asInstanceOf[AnyRef]
+      case 5 => {
         val schema = getSchema.getFields().get(field$).schema()
         val decimalType = schema.getLogicalType().asInstanceOf[org.apache.avro.LogicalTypes.Decimal]
         val scale = decimalType.getScale()
@@ -46,28 +54,37 @@ final case class LogicalSc(var data: BigDecimal, var fxField: BigDecimal, var ts
           }
         }
       }.asInstanceOf[BigDecimal]
-      case 1 => this.ts = {
+      case 1 => this.fxField = {
+        value match {
+          case (buffer: java.nio.ByteBuffer) => {
+            val schema = getSchema.getFields().get(field$).schema()
+            val decimalType = schema.getLogicalType().asInstanceOf[org.apache.avro.LogicalTypes.Decimal]
+            BigDecimal(LogicalSc.decimalConversion.fromBytes(buffer, schema, decimalType))
+          }
+        }
+      }.asInstanceOf[BigDecimal]
+      case 2 => this.ts = {
         value match {
           case (l: Long) => {
             java.time.Instant.ofEpochMilli(l)
           }
         }
       }.asInstanceOf[java.time.Instant]
-      case 2 => this.dt = {
+      case 3 => this.dt = {
         value match {
           case (i: Integer) => {
             java.time.LocalDate.ofEpochDay(i.toInt)
           }
         }
       }.asInstanceOf[java.time.LocalDate]
-      case 3 => this.uuid = {
+      case 4 => this.uuid = {
         value match {
           case (chars: java.lang.CharSequence) => {
             java.util.UUID.fromString(chars.toString)
           }
         }
       }.asInstanceOf[java.util.UUID]
-      case 4 => this.dataBig = {
+      case 5 => this.dataBig = {
         value match {
           case (buffer: java.nio.ByteBuffer) => {
             val schema = getSchema.getFields().get(field$).schema()
@@ -84,6 +101,6 @@ final case class LogicalSc(var data: BigDecimal, var fxField: BigDecimal, var ts
 }
 
 object LogicalSc {
-  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"LogicalSc\",\"namespace\":\"example.logical\",\"fields\":[{\"name\":\"data\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2}},{\"name\":\"ts\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}},{\"name\":\"dt\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},{\"name\":\"uuid\",\"type\":{\"type\":\"string\",\"logicalType\":\"uuid\"}},{\"name\":\"dataBig\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12}}]}")
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"LogicalSc\",\"namespace\":\"example.logical\",\"fields\":[{\"name\":\"data\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":9,\"scale\":2}},{\"name\":\"fxField\",\"type\":{\"type\":\"fixed\",\"name\":\"fxType\",\"size\":12,\"logicalType\":\"decimal\",\"precision\":5,\"scale\":2}},{\"name\":\"ts\",\"type\":{\"type\":\"long\",\"logicalType\":\"timestamp-millis\"}},{\"name\":\"dt\",\"type\":{\"type\":\"int\",\"logicalType\":\"date\"}},{\"name\":\"uuid\",\"type\":{\"type\":\"string\",\"logicalType\":\"uuid\"}},{\"name\":\"dataBig\",\"type\":{\"type\":\"bytes\",\"logicalType\":\"decimal\",\"precision\":20,\"scale\":12}}]}")
   val decimalConversion = new org.apache.avro.Conversions.DecimalConversion
 }

--- a/avrohugger-core/src/test/expected/specific/example/logical/proto/Logical.scala
+++ b/avrohugger-core/src/test/expected/specific/example/logical/proto/Logical.scala
@@ -4,7 +4,7 @@ package example.logical.proto
 import scala.annotation.switch
 
 final case class Logical(var dec: BigDecimal, var ts: java.time.Instant, var dt: java.time.LocalDate, var uuid: java.util.UUID, var decBig: BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(scala.math.BigDecimal(0), scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
+  def this() = this(scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {

--- a/avrohugger-core/src/test/expected/specific/example/logical/proto/Logical.scala
+++ b/avrohugger-core/src/test/expected/specific/example/logical/proto/Logical.scala
@@ -4,7 +4,7 @@ package example.logical.proto
 import scala.annotation.switch
 
 final case class Logical(var dec: BigDecimal, var ts: java.time.Instant, var dt: java.time.LocalDate, var uuid: java.util.UUID, var decBig: BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
+  def this() = this(scala.math.BigDecimal(0), scala.math.BigDecimal(0), java.time.Instant.now, java.time.LocalDate.now, java.util.UUID.randomUUID, scala.math.BigDecimal(0))
   def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -3,11 +3,11 @@ package test
 package standard
 
 import java.io.File
-
 import avrohugger._
 import avrohugger.format.Standard
 import avrohugger.types._
 import org.specs2._
+import util.Util.checkFileExist
 
 import scala.util.Try
 
@@ -571,9 +571,7 @@ class StandardFileToFileSpec extends Specification {
     val gen = new Generator(Standard)
     val outDir = gen.defaultOutputDir + "/standard/"
     gen.fileToFile(infile, outDir)
-
-    val source = util.Util.readFile("target/generated-sources/standard/example/logical/Fixed.scala")
-
-    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/logical/Fixed.scala")
+    
+    checkFileExist("avrohugger-core/src/test/expected/standard/example/logical/Fixed.scala") === false
   }
 }

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -59,6 +59,8 @@ class StandardFileToFileSpec extends Specification {
     correctly generate an either containing logical types from IDL tagged decimals $e37
     correctly generate a coproduct containing logical types from IDL tagged decimals $e38
     correctly generate a protocol with special strings $e39
+
+    correctly generate fixed from schema $e40
   """
   
   // tests standard to fileToX
@@ -91,7 +93,7 @@ class StandardFileToFileSpec extends Specification {
     val outDir = gen.defaultOutputDir + "/standard/"
     gen.fileToFile(infile, outDir)
 
-    (new File(s"target/generated-sources/standard/example/idl/ExternalDependency.scala")).exists === false
+    new File(s"target/generated-sources/standard/example/idl/ExternalDependency.scala").exists === false
   }
 
   // tests common to fileToX and stringToX
@@ -562,5 +564,16 @@ class StandardFileToFileSpec extends Specification {
     val source = util.Util.readFile("target/generated-sources/standard/example/idl/Names.scala")
 
     source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/idl/Names.scala")
+  }
+
+  def e40 = {
+    val infile = new File("avrohugger-core/src/test/avro/fixed.avsc")
+    val gen = new Generator(Standard)
+    val outDir = gen.defaultOutputDir + "/standard/"
+    gen.fileToFile(infile, outDir)
+
+    val source = util.Util.readFile("target/generated-sources/standard/example/logical/Fixed.scala")
+
+    source === util.Util.readFile("avrohugger-core/src/test/expected/standard/example/logical/Fixed.scala")
   }
 }

--- a/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
+++ b/avrohugger-core/src/test/scala/standard/StandardFileToFileSpec.scala
@@ -571,7 +571,7 @@ class StandardFileToFileSpec extends Specification {
     val gen = new Generator(Standard)
     val outDir = gen.defaultOutputDir + "/standard/"
     gen.fileToFile(infile, outDir)
-    
+
     checkFileExist("avrohugger-core/src/test/expected/standard/example/logical/Fixed.scala") === false
   }
 }

--- a/avrohugger-core/src/test/scala/util/Util.scala
+++ b/avrohugger-core/src/test/scala/util/Util.scala
@@ -14,7 +14,16 @@ object Util {
           else sys.error("File not found: " + fileName)
       }
     }
+
     readFile0(0)
   }
+
+  def checkFileExist(fileName: String): Boolean =
+    try {
+      scala.io.Source.fromFile(fileName).close()
+      true
+    } catch {
+      case e: Throwable => false
+    }
 
 }

--- a/avrohugger-filesorter/src/test/resources/avro/amain/fixedRecord.avsc
+++ b/avrohugger-filesorter/src/test/resources/avro/amain/fixedRecord.avsc
@@ -1,0 +1,26 @@
+{
+  "type": "record",
+  "namespace": "com.test",
+  "name": "fixedRecord",
+  "doc": "Top-level schema testing fully-qualified dependent schema names",
+  "fields": [{
+    "doc": "fully-qualified dependent union field",
+    "name": "b",
+    "type": ["null", "int"]
+  },{
+    "doc": "fully-qualified dependent fixed field",
+    "name": "c",
+    "type": [
+      "null",
+      "com.test.Money"
+    ]
+  },{
+    "doc": "fully-qualified dependent array field",
+    "name": "d",
+    "type": {
+      "type": "array",
+      "items": "int"
+    }
+  }
+  ]
+}

--- a/avrohugger-filesorter/src/test/resources/avro/imports/fixed.avsc
+++ b/avrohugger-filesorter/src/test/resources/avro/imports/fixed.avsc
@@ -1,0 +1,9 @@
+{
+  "type": "fixed",
+  "size": 12,
+  "namespace": "com.test",
+  "name": "Money",
+  "logicalType": "decimal",
+  "precision": 28,
+  "scale": 15
+}

--- a/avrohugger-filesorter/src/test/scala/test/FileSorterSpec.scala
+++ b/avrohugger-filesorter/src/test/scala/test/FileSorterSpec.scala
@@ -21,6 +21,12 @@ class FileSorterSpec extends Specification {
     new File(sourceDir, "d.avsc"),
     new File(sourceDir, "e.avsc"))
 
+
+  val fixedNames = Seq(
+    new File(sourceDir, "amain/fixedRecord.avsc"),
+    new File(sourceDir, "imports/fixed.avsc")
+  )
+
   val simpleNames = Seq(
     new File(sourceDir, "_a.avsc"),
     new File(sourceDir, "_b.avsc"),
@@ -39,6 +45,11 @@ class FileSorterSpec extends Specification {
     new File(sourceDir, "d.avsc"),
     new File(sourceDir, "b.avsc"),
     new File(sourceDir, "a.avsc"))
+
+  val expectedOrderFixedNames = Seq(
+    new File(sourceDir, "imports/fixed.avsc"),
+    new File(sourceDir, "amain/fixedRecord.avsc")
+  )
 
   val expectedOrderSimpleNames = Seq(
     new File(sourceDir, "_c.avsc"),
@@ -60,6 +71,10 @@ class FileSorterSpec extends Specification {
     AvscFileSorter.sortSchemaFiles(fullyQualifiedNames.reverse) must beEqualTo(expectedOrderFullyQualifiedNames)
     AvscFileSorter.sortSchemaFiles(simpleNames) must beEqualTo(expectedOrderSimpleNames)
     AvscFileSorter.sortSchemaFiles(simpleNames.reverse) must beEqualTo(expectedOrderSimpleNames)
+  }
+
+  "Schema files with Fixed type should be sorted" >> {
+    AvscFileSorter.sortSchemaFiles(fixedNames) must beEqualTo(expectedOrderFixedNames)
   }
   
   "AVDL files should be sorted correctly for imports" >> {

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val avroVersion = "1.9.1"
 
 lazy val commonSettings = Seq(
   organization := "com.julianpeeters",
-  version := "1.0.0-RC25",
+  version := "1.0.0-RC25-TTD",
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
   Test / scalacOptions ++= Seq("-Yrangepos"),
   scalaVersion := "2.13.4",

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,14 @@ lazy val commonSettings = Seq(
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-value-discard"),
   Test / scalacOptions ++= Seq("-Yrangepos"),
   scalaVersion := "2.13.4",
-  crossScalaVersions := Seq("2.12.10", scalaVersion.value),
+  crossScalaVersions := Seq("2.12.11", scalaVersion.value),
   resolvers += Resolver.typesafeIvyRepo("releases"),
   libraryDependencies += "org.apache.avro" % "avro" % avroVersion,
   libraryDependencies += "org.apache.avro" % "avro-compiler" % avroVersion,
   libraryDependencies := { CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, scalaMajor)) if scalaMajor < 13 =>
       // for implementing SpecificRecord from standard case class definitions
-      libraryDependencies.value ++ Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full))
+      libraryDependencies.value ++ Seq(compilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full))
 
     case _ =>
       // Scala 2.13 has it built-in


### PR DESCRIPTION
 * Added support for Fixed data type (for STANDARD format only) with logical type Decimal. No case class is generated for fixed - applied in place as BigDecimal.
* Version of Scala for cross-compilation updated to 2.12.11
* Added test for Fixed data type.

